### PR TITLE
Fix parsing of item type to string

### DIFF
--- a/src/cn/citycraft/PluginHelper/utils/LocalUtil.java
+++ b/src/cn/citycraft/PluginHelper/utils/LocalUtil.java
@@ -2,6 +2,7 @@ package cn.citycraft.PluginHelper.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import me.desht.clicksort.ClickSortPlugin;
@@ -10,7 +11,6 @@ import me.desht.dhutils.JARUtil;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.SpawnEgg;
 import org.bukkit.plugin.Plugin;
 
 public class LocalUtil {
@@ -46,17 +46,8 @@ public class LocalUtil {
         return aname;
     }
     
-    @SuppressWarnings("deprecation")
     public static final String getItemType(final ItemStack i) {
-        String name = i.getType().name();
-        String dura = "";
-        if (i.getType().name().endsWith("_EGG")) {
-            name = ((SpawnEgg) i.getData()).getSpawnedType().name();
-        } else {
-            final int dur = i.getDurability();
-            dura = (i.getMaxStackSize() != 1 && dur != 0) ? Integer.toString(dur) : "";
-        }
-        return (name + (dura.isEmpty() ? "" : "-" + dura)).toUpperCase();
+        return i.getType().name().toUpperCase(Locale.ROOT);
     }
 
     public static void init(final Plugin plugin) {


### PR DESCRIPTION
This is no longer needed since all item variants have their own Material since 1.13. It also causes a class cast exception because spawn eggs now use the default ItemMeta instead of SpawnEgg.