### PR TITLE
Change version checks to official Bukkit API

### DIFF
--- a/src/main/java/me/desht/dhutils/CompatUtil.java
+++ b/src/main/java/me/desht/dhutils/CompatUtil.java
@@ -4,10 +4,9 @@ import org.bukkit.Bukkit;
 
 public class CompatUtil {
     public static int GetMinecraftSubVersion() {
-        String a = Bukkit.getServer().getClass().getPackage().getName();
-        String version = a.substring(a.lastIndexOf('.') + 1);
-        String[] subVersions = version.split("_");
-        return Integer.parseInt(subVersions[1]);
+        String minecraftVersion = Bukkit.getServer().getBukkitVersion().split("-")[0];
+        String subVersion = minecraftVersion.split("\\.")[1];
+        return Integer.parseInt(subVersion);
     }
 
     public static boolean isMaterialIdAllowed() {


### PR DESCRIPTION
ClickSort currently relies on internal package names (e.g., v1_20_R4) to detect the Minecraft version. Recent paper versions drop this package convention (https://forums.papermc.io/threads/important-dev-psa-future-removal-of-cb-package-relocation.1106/).

This MR changes the method to use the official Bukkit API for version checking instead of relying on internal, undocumented features, which should be more stable going forward.

Fixes #18 